### PR TITLE
Add treeview and tabbed layout to dashboard

### DIFF
--- a/Dashboard/Dashboard.css
+++ b/Dashboard/Dashboard.css
@@ -145,3 +145,68 @@ body {
   outline: none;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
+
+/* Hauptlayout */
+.dashboard-wrapper {
+  display: flex;
+  height: calc(100vh - 40px);
+  padding-top: 40px; /* Platz für die Menüleiste */
+}
+
+/* Treeview auf der linken Seite */
+.treeview {
+  width: 220px;
+  border-right: 1px solid #ddd;
+  padding: 10px;
+  overflow-y: auto;
+  font-size: 14px;
+}
+
+.tree li {
+  list-style: none;
+  margin-left: 10px;
+}
+
+/* Bereich für Tabs */
+.tab-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.tabs {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid #ddd;
+  background: #f5f5f5;
+}
+
+.tab {
+  padding: 6px 20px 6px 10px;
+  cursor: pointer;
+  position: relative;
+  margin-right: 2px;
+}
+
+.tab.active {
+  background: white;
+  border-bottom: 2px solid #333;
+}
+
+.close-btn {
+  margin-left: 6px;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.add-tab {
+  padding: 6px 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.tab-content {
+  flex: 1;
+  padding: 10px;
+  overflow: auto;
+}

--- a/Dashboard/Dashboard.html
+++ b/Dashboard/Dashboard.html
@@ -53,6 +53,25 @@
     </div>
   </nav>
 
+  <div class="dashboard-wrapper">
+    <div class="treeview">
+      <ul class="tree">
+        <li>Root
+          <ul>
+            <li>Child 1</li>
+            <li>Child 2</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+    <div class="tab-area">
+      <div class="tabs">
+        <div class="add-tab">+</div>
+      </div>
+      <div class="tab-content"></div>
+    </div>
+  </div>
+
   <script src="/Dashboard/Dashboard.js"></script>
 </body>
 

--- a/Dashboard/Dashboard.js
+++ b/Dashboard/Dashboard.js
@@ -22,4 +22,50 @@ document.addEventListener("DOMContentLoaded", () => {
       menuBar.classList.remove("visible");
     }
   });
+
+  const tabsContainer = document.querySelector(".tabs");
+  const addButton = document.querySelector(".add-tab");
+  const content = document.querySelector(".tab-content");
+
+  function setActiveTab(tab) {
+    document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"));
+    tab.classList.add("active");
+    content.textContent = tab.dataset.title;
+  }
+
+  function createTab(title) {
+    const tab = document.createElement("div");
+    tab.classList.add("tab");
+    tab.dataset.title = title;
+    tab.textContent = title;
+    const close = document.createElement("span");
+    close.classList.add("close-btn");
+    close.textContent = "\u00d7";
+    tab.appendChild(close);
+
+    tab.addEventListener("click", () => setActiveTab(tab));
+
+    close.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const wasActive = tab.classList.contains("active");
+      tab.remove();
+      if (wasActive) {
+        const next = tabsContainer.querySelector(".tab");
+        if (next) setActiveTab(next);
+        else content.textContent = "";
+      }
+    });
+
+    tabsContainer.insertBefore(tab, addButton);
+    return tab;
+  }
+
+  addButton.addEventListener("click", () => {
+    const index = tabsContainer.querySelectorAll(".tab").length + 1;
+    const tab = createTab("Tab " + index);
+    setActiveTab(tab);
+  });
+
+  const first = createTab("Tab 1");
+  setActiveTab(first);
 });


### PR DESCRIPTION
## Summary
- expand the dashboard with a sidebar treeview and a tabbed area
- update CSS for layout and tab styling
- implement dynamic tab creation and closing in JS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685baea31968832681ff9decfdc0658c